### PR TITLE
Corrected openssl default path

### DIFF
--- a/src/portable_python/external/xcpython.py
+++ b/src/portable_python/external/xcpython.py
@@ -145,10 +145,10 @@ class Openssl(ModuleBuilder):
 
     @property
     def version(self):
-        return self.cfg_version("1.1.1p")
+        return self.cfg_version("1.1.1q")
 
     def c_configure_args(self):
-        yield f"--openssldir={self.deps}"
+        yield f"--openssldir=/etc/ssl"
         yield "-DPEDANTIC"
         yield "no-shared", "no-idea", "no-tests"
         if PPG.target.is_macos:

--- a/src/portable_python/external/xcpython.py
+++ b/src/portable_python/external/xcpython.py
@@ -148,7 +148,7 @@ class Openssl(ModuleBuilder):
         return self.cfg_version("1.1.1q")
 
     def c_configure_args(self):
-        yield f"--openssldir=/etc/ssl"
+        yield "--openssldir=/etc/ssl"
         yield "-DPEDANTIC"
         yield "no-shared", "no-idea", "no-tests"
         if PPG.target.is_macos:


### PR DESCRIPTION
Use `/etc/ssl` for `--openssldir`, so the default paths don't end up defaulting to original build folder