### PR TITLE
Bumped min mac target

### DIFF
--- a/src/portable_python/config.py
+++ b/src/portable_python/config.py
@@ -71,10 +71,7 @@ windows:
 macos:
   allowed-system-libs: .*  # System libs on macos are OK (such as bz2 etc)
   env:
-    MACOSX_DEPLOYMENT_TARGET: 10.14
-  arm64:
-    env:
-      MACOSX_DEPLOYMENT_TARGET: 12
+    MACOSX_DEPLOYMENT_TARGET: 13  # Ventura, released June 2022
 """
 
 


### PR DESCRIPTION
MACOSX_DEPLOYMENT_TARGET influences what features for macos libs are "enabled". Produced binary will work on state version and above.