### PR TITLE
Use `ruff` instead of `flake8`, turn on more lint checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,4 +59,4 @@ jobs:
         python-version: "3.11"
 
     - run: pip install -U pip tox
-    - run: tox -e docs,style,security
+    - run: tox -e docs,style

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,79 @@
 [build-system]
 requires = ["setuptools", "wheel"]
+
+[tool.ruff]
+cache-dir = ".tox/.ruff_cache"
+line-length = 140
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+extend-select = [
+    "A",   # flake8-builtins
+#    "ARG", # flake8-unused-arguments
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "C90", # mccabe
+    "D",   # pydocstyle
+    "DTZ", # flake8-datetimez
+    "E",   # pycodestyle errors
+    "EM",  # flake8-errmsg
+    "ERA", # eradicate
+    "EXE", # flake8-executable
+    "F",   # pyflakes
+    "FLY", # flynt
+    "G",   # flake8-logging-format
+    "I",   # isort
+    "INT", # flake8-gettext
+    "PD",  # pandas-vet
+    "PGH", # pygrep-hooks
+    "PIE", # flake8-pie
+    "PT", # flake8-pytest
+    "PYI", # flake8-pyi
+    "Q",   # flake8-quotes
+    "RSE", # flake8-raise
+    "RET", # flake8-return
+    "RUF", # ruff-specific
+    "S",   # flake8-bandit
+#    "SIM", # flake8-simplify
+    "SLF", # flake8-self
+    "SLOT", # flake8-slots
+    "T10", # flake8-debugger
+    "TID", # flake8-tidy-imports
+    "TCH", # flake8-type-checking
+#    "TD", # flake8-todos
+    "TRY", # tryceratops
+    "W",   # pycodestyle warnings
+]
+ignore = [
+    # TODO: gradually remove these (document all the things)
+    "D100",  # Missing docstring in public module
+    "D101",  # Missing docstring in public class
+    "D102",  # Missing docstring in public method
+    "D103",  # Missing docstring in public function
+    "D104",  # Missing docstring in public package
+    "D105",  # Missing docstring in magic method
+    "D200",  # One-line docstring should fit on one line with quotes
+    "D205",  # 1 blank line required between summary line and description
+    "D400",  # First line should end with a period
+    "D401",  # First line should be in imperative mood
+    "D404",  # First word of the docstring should not be This
+    # Not useful:
+    "RET503",  # Missing explicit `return` at the end of function able to return non-`None` value
+]
+
+[tool.ruff.lint.flake8-builtins]
+builtins-ignorelist = ["bin", "compile"]
+
+[tool.ruff.lint.isort]
+order-by-type = false
+
+[tool.ruff.lint.mccabe]
+max-complexity = 14
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.per-file-ignores]
+"tests/*" = [
+    "S",  # No security checks for tests
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,6 @@ ignore = [
     "D200",  # One-line docstring should fit on one line with quotes
     "D205",  # 1 blank line required between summary line and description
     "D400",  # First line should end with a period
-    "D401",  # First line should be in imperative mood
-    "D404",  # First word of the docstring should not be This
     # Not useful:
     "RET503",  # Missing explicit `return` at the end of function able to return non-`None` value
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ extend-select = [
     "G",   # flake8-logging-format
     "I",   # isort
     "INT", # flake8-gettext
-    "PD",  # pandas-vet
     "PGH", # pygrep-hooks
     "PIE", # flake8-pie
     "PT", # flake8-pytest

--- a/retired/toolchain.py
+++ b/retired/toolchain.py
@@ -40,7 +40,6 @@ class PkgConfig(ModuleBuilder):
 
     @property
     def url(self):
-        # return f"https://github.com/freedesktop/pkg-config/archive/refs/tags/pkg-config-{self.version}.tar.gz"
         return f"https://pkg-config.freedesktop.org/releases/pkg-config-{self.version}.tar.gz"
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from setuptools import setup
 
-
 setup(
     name="portable-python",
     setup_requires="setupmeta",

--- a/src/portable_python/__init__.py
+++ b/src/portable_python/__init__.py
@@ -35,11 +35,16 @@ def is_binary_file(path):
 def patch_folder(folder, regex, replacement, ignore=None):
     """Replace all occurrences of 'old_text' by 'new_text' in all files in 'folder'
 
-    Args:
-        folder (pathlib.Path): Folder to scan
-        regex: Regex to replace
-        replacement (str): Replacement text
-        ignore: Regex stating what to ignore
+    Parameters
+    ----------
+    folder : pathlib.Path
+        Folder to scan
+    regex : str
+        Regex to replace
+    replacement : str
+        Replacement text
+    ignore : re.Pattern | None
+        Regex stating what to ignore
     """
     for path in runez.ls_dir(folder):
         if not path.is_symlink() and (not ignore or not ignore.match(path.name)):
@@ -117,10 +122,12 @@ class BuildContext:
 
     def _resolved_isolation(self):
         """
+        Isolation setting currently configured.
+
         Returns
         -------
-            str | None
-                What strategy to use to work around the fact that python's ./configure script looks at /usr/local
+        str | None
+            What strategy to use to work around the fact that python's ./configure script looks at /usr/local
         """
         v = PPG.config.get_value("isolate-usr-local")
         if v == "auto":
@@ -183,7 +190,7 @@ class BuildContext:
 
 class BuildSetup:
     """
-    This class drives the compilation, external modules first, then the target python itself.
+    Drives the compilation, external modules first, then the target python itself.
     All modules are compiled in the same manner, follow the same conventional build layout.
     """
 
@@ -192,10 +199,14 @@ class BuildSetup:
 
     def __init__(self, python_spec=None, modules=None, prefix=None):
         """
-        Args:
-            python_spec (str | PythonSpec | None): Python to build (family and version)
-            modules (str | None): Modules to build (default: from config)
-            prefix (str | None): --prefix to use
+        Parameters
+        ----------
+        python_spec : str | PythonSpec | None
+            Python to build (family and version)
+        modules : str | None
+            Modules to build (default: from config)
+        prefix : str | None
+            --prefix to use
         """
         if not python_spec or python_spec == "latest":
             python_spec = PPG.cpython.latest
@@ -397,8 +408,10 @@ class ModuleBuilder:
 
     def __init__(self, parent_module):
         """
-        Args:
-            parent_module (BuildSetup | ModuleBuilder): Associated parent
+        Parameters
+        ----------
+        parent_module : BuildSetup | ModuleBuilder
+            Associated parent
         """
         self.m_name = ModuleCollection.get_module_name(self.__class__)
         if isinstance(parent_module, BuildSetup):
@@ -526,8 +539,7 @@ class ModuleBuilder:
 
     def run_configure(self, program, *args, prefix=None):
         """
-        Calling ./configure is similar across all components.
-        This allows to have descendants customize each part relatively elegantly
+        Run ./configure script for this module.
         """
         if prefix is None:
             prefix = self.deps

--- a/src/portable_python/cli.py
+++ b/src/portable_python/cli.py
@@ -8,7 +8,6 @@ from runez.render import PrettyTable
 from portable_python import BuildSetup, PPG
 from portable_python.inspector import LibAutoCorrect, PythonInspector
 
-
 LOG = logging.getLogger(__name__)
 
 
@@ -60,10 +59,6 @@ def build_report(modules, python_spec):
 def diagnostics():
     """Show diagnostics info"""
     with runez.Anchored("."):
-        def _diagnostics():
-            yield "invoker python", runez.SYS_INFO.invoker_python
-            yield from runez.SYS_INFO.diagnostics()
-
         config = PPG.config.represented()
         print(PrettyTable.two_column_diagnostics(_diagnostics(), config))
 
@@ -104,6 +99,11 @@ def list_cmd(json, family):
     print("%s:" % runez.bold(family))
     for mm, v in fam.available_versions.items():
         print("  %s: %s" % (runez.bold(mm), v))
+
+
+def _diagnostics():
+    yield "invoker python", runez.SYS_INFO.invoker_python
+    yield from runez.SYS_INFO.diagnostics()
 
 
 def _find_recompress_source(folders, path):
@@ -158,7 +158,7 @@ def recompress(path, ext):
 
     \b
     Mildly useful for comparing sizes from different compressions
-    """
+    """  # noqa: D301
     extension = runez.SYS_INFO.platform_id.canonical_compress_extension(ext)
     pspec = PythonSpec.from_text(path)
     folders = PPG.get_folders(base=".", family=pspec and pspec.family, version=pspec and pspec.version)
@@ -203,6 +203,6 @@ def lib_auto_correct(commit, prefix, path):
 
 
 if __name__ == "__main__":
-    from portable_python.cli import main  # noqa, re-import with proper package
+    from portable_python.cli import main
 
     main()

--- a/src/portable_python/config.py
+++ b/src/portable_python/config.py
@@ -78,9 +78,12 @@ class Config:
 
     def __init__(self, paths=None, target=None):
         """
-        Args:
-            paths (str | list | None): Path(s) to config file(s)
-            target (str | runez.system.PlatformId | None): Target platform (for testing, defaults to current platform)
+        Parameters
+        ----------
+        paths : str | list | None
+            Path(s) to config file(s)
+        target : str | runez.system.PlatformId | None
+            Target platform (for testing, defaults to current platform)
         """
         self.paths = runez.flattened(paths, split=",")
         if not isinstance(target, runez.system.PlatformId):
@@ -195,10 +198,14 @@ class Config:
 
     def cleanup_configured_globs(self, title, module, *keys):
         """
-        Args:
-            title (str): Title to use in log messages
-            module (portable_python.PythonBuilder): Associated python builder module
-            *keys (str): Config keys to lookup
+        Parameters
+        ----------
+        title : str
+            Title to use in log messages
+        module : portable_python.PythonBuilder
+            Associated python builder module
+        *keys : str
+            Config keys to lookup
         """
         globs = [(x, f"{x}-{self.target.platform}") for x in keys]
         globs = runez.flattened(globs, transform=self.get_value)
@@ -207,10 +214,14 @@ class Config:
 
     def cleanup_globs(self, title, module, *globs):
         """
-        Args:
-            title (str): Title to use in log messages
-            module (portable_python.PythonBuilder): Associated python builder module
-            *globs (str): Glob patterns to clean up
+        Parameters
+        ----------
+        title : str
+            Title to use in log messages
+        module : portable_python.PythonBuilder
+            Associated python builder module
+        *globs : str
+            Glob patterns to clean up
         """
         if globs:
             spec = [module.setup.folders.formatted(x) for x in globs]

--- a/src/portable_python/config.py
+++ b/src/portable_python/config.py
@@ -9,7 +9,6 @@ import runez
 import yaml
 from runez.pyenv import Version
 
-
 LOG = logging.getLogger(__name__)
 
 DEFAULT_CONFIG = """
@@ -98,17 +97,21 @@ class Config:
         return "%s [%s]" % (runez.plural(self._sources, "config source"), self.target)
 
     def completions(self, **given):
-        res = dict(arch=self.target.arch, platform=self.target.platform, subsystem=self.target.subsystem, target=str(self.target))
+        res = {"arch": self.target.arch, "platform": self.target.platform, "subsystem": self.target.subsystem, "target": str(self.target)}
         res.update(given)
         return res
 
     def get_value(self, *key, by_platform=True):
         """
-        Args:
-            key (str | tuple): Key to look up, tuple represents hierarchy, ie: a/b -> (a, b)
-            by_platform (bool): If True, value can be configured by platform
+        Parameters
+        ----------
+        key : strzz | tuple
+            Key to look up, tuple represents hierarchy, ie: a/b -> (a, b)
+        by_platform : bool
+            If True, value can be configured by platform
 
-        Returns:
+        Returns
+        -------
             Associated value, if any
         """
         value, _ = self.get_entry(*key, by_platform=by_platform)
@@ -116,18 +119,23 @@ class Config:
 
     def get_entry(self, *key, by_platform=True):
         """
-        Args:
-            key (str | tuple): Key to look up, tuple represents hierarchy, ie: a/b -> (a, b)
-            by_platform (bool): If True, value can be configured by platform
+        Parameters
+        ----------
+        key : str | tuple
+            Key to look up, tuple represents hierarchy, ie: a/b -> (a, b)
+        by_platform : bool
+            If True, value can be configured by platform
 
-        Returns:
-            Associated value, if any
+        Returns
+        -------
+        (str | int | float | bool | dict | list | None, ConfigSource | None)
+            Associated value (if any), together with the source that defined it
         """
         if by_platform:
             keys = (self.target.platform, self.target.arch, *key), (self.target.platform, *key), key
 
         else:
-            keys = (key, )
+            keys = (key,)
 
         for k in keys:
             for source in self._sources:
@@ -150,7 +158,7 @@ class Config:
         return value
 
     def config_files_report(self):
-        """One liner describing which config files are used, if any"""
+        """One-liner describing which config files are used, if any"""
         if len(self._sources) > 1:
             return "Config files: %s" % runez.joined(self._sources[:-1], delimiter=", ")
 
@@ -174,7 +182,7 @@ class Config:
     def delete(path):
         size = runez.filesize(path)
         runez.delete(path, logger=None)
-        LOG.info("Deleted %s (%s)" % (runez.short(path), runez.represented_bytesize(size)))
+        LOG.info("Deleted %s (%s)", runez.short(path), runez.represented_bytesize(size))
         return size
 
     @staticmethod
@@ -208,7 +216,7 @@ class Config:
             spec = [module.setup.folders.formatted(x) for x in globs]
             deleted_size = 0
             matcher = FileMatcher(spec)
-            LOG.info("Applying clean-up spec: %s" % matcher)
+            LOG.info("Applying clean-up spec: %s", matcher)
             cleaned = []
             for dirpath, dirnames, filenames in os.walk(module.install_folder):
                 removed = []
@@ -241,7 +249,7 @@ class Config:
             _find_file_duplicates(seen, folder)
             duplicates = {k: v for k, v in seen.items() if len(v) > 1}
             for dupes in duplicates.values():
-                LOG.info("Found duplicates: %s" % runez.joined(dupes, delimiter=", "))
+                LOG.info("Found duplicates: %s", runez.joined(dupes, delimiter=", "))
                 dupes = sorted(dupes, key=lambda x: len(str(x)))
                 if len(dupes) == 2:
                     shorter, longer = dupes
@@ -261,14 +269,19 @@ class Config:
         return basename, "%s%s" % (basename, version.major), "%s%s" % (basename, version.mm)
 
     @staticmethod
-    def find_main_file(desired: pathlib.Path, version: Version):
+    def find_main_file(desired, version):
         """
-        Args:
-            desired: Desired path (base name considered if path not directly available)
-            version: Associated version
+        Parameters
+        ----------
+        desired : pathlib.Path
+            Desired path (base name considered if path not directly available)
+        version : Version
+            Associated version
 
-        Returns:
-            (pathlib.Path | None): Path to associated real file (not symlink)
+        Returns
+        -------
+        pathlib.Path | None
+            Path to associated real file (not symlink)
         """
         p = Config.real_path(desired)
         if p:
@@ -335,10 +348,14 @@ class ConfigSource:
 
     def get_value(self, key):
         """
-        Args:
-            key (str | tuple): Key to look up, tuple represents hierarchy, ie: a/b -> (a, b)
+        Parameters
+        ----------
+        key : str | tuple
+            Key to look up, tuple represents hierarchy, ie: a/b -> (a, b)
 
-        Returns:
+        Returns
+        -------
+        str | int | float | bool | dict | list | None
             Associated value, if any
         """
         return self._deep_get(self.data, key)
@@ -360,7 +377,6 @@ class ConfigSource:
 
 
 class FileMatcher:
-
     def __init__(self, clean_spec):
         self.matches = []
         for spec in clean_spec:
@@ -376,7 +392,6 @@ class FileMatcher:
 
 
 class SingleFileMatch:
-
     _on_folder = False
     _rx_basename = None
     _rx_path = None

--- a/src/portable_python/cpython.py
+++ b/src/portable_python/cpython.py
@@ -23,7 +23,7 @@ test_struct test_threading test_time test_traceback test_unicode
 
 def represented_yaml(key_value_pairs):
     """
-    Represented yaml for given key/value pairs
+    Yaml representation for given key/value pairs
 
     Parameters
     ----------
@@ -50,9 +50,13 @@ class Cpython(PythonBuilder):
 
     def build_information(self):
         """
-        Yields key/value pairs to store as build information.
+        Build information to store in manifest.
         `None` or empty values are "naturally" omitted by the fact we use `runez.joined()` and `runez.flattened()`,
-         which have a default parameter `keep_empty=False`
+         which have a default parameter `keep_empty=False`.
+
+        Yields
+        ------
+        (str, dict)
         """
         yield (
             "cpython",

--- a/src/portable_python/external/_inspect.py
+++ b/src/portable_python/external/_inspect.py
@@ -4,7 +4,6 @@ import re
 import sys
 import sysconfig
 
-
 RX_VERSION = re.compile(r"\d\.\d")
 INSIGHTS = {
     "_gdbm": "_GDBM_VERSION",
@@ -38,7 +37,7 @@ def get_version(text):
 def pymodule_version_info(key, value, pymodule):
     version = get_version(value)
     if version:
-        result = dict(version_field=key, version=version)
+        result = {"version_field": key, "version": version}
         if hasattr(pymodule, "__file__"):
             result["path"] = pymodule.__file__
 
@@ -54,14 +53,14 @@ def pymodule_info(module_name, pymodule):
             return v
 
     if hasattr(pymodule, "__file__"):
-        return dict(path=pymodule.__file__)
+        return {"path": pymodule.__file__}
 
     if hasattr(pymodule, "__spec__"):
-        v = getattr(pymodule.__spec__, "origin")
+        v = getattr(pymodule.__spec__, "origin", None)
         if v == "built-in":
-            return dict(version=v)
+            return {"version": v}
 
-    return dict(note=str(dir(pymodule)))
+    return {"note": str(dir(pymodule))}
 
 
 def module_report(module_name):
@@ -71,9 +70,9 @@ def module_report(module_name):
     except Exception as e:
         note = str(e)
         if "No module named" in note:
-            return dict(version="*absent*")
+            return {"version": "*absent*"}
 
-        return dict(version="*absent*", note=note)
+        return {"version": "*absent*", "note": note}
 
 
 def get_srcdir():
@@ -92,7 +91,7 @@ def get_simplified_dirs(path):
         if path.startswith("/private"):
             result.append(path[8:])  # whoever compiled didn't use realpath(tmp)
 
-        elif not path.startswith("/tmp"):  # nosec, just simplifying paths
+        elif not path.startswith("/tmp"):  # noqa: S108, just simplifying path representation
             result.append(os.path.dirname(result[0]))
 
     return result
@@ -121,8 +120,8 @@ def main(arg):
             names.remove("pip")
             names.append("pip")
 
-        report = dict((k, module_report(k)) for k in names)
-        report = dict(report=report, srcdir=get_srcdir(), prefix=sysconfig.get_config_var("prefix"))
+        report = dict((k, module_report(k)) for k in names)  # noqa: C402, works on py2 as well (can inspect py2)
+        report = {"report": report, "srcdir": get_srcdir(), "prefix": sysconfig.get_config_var("prefix")}
         print(json.dumps(report, indent=2, sort_keys=True))
 
 

--- a/src/portable_python/external/tkinter.py
+++ b/src/portable_python/external/tkinter.py
@@ -5,6 +5,8 @@ It is also unclear what version to use, which build docs to follow etc.
 Contributions are welcome!
 """
 
+from typing import ClassVar
+
 import runez
 
 from portable_python import ModuleBuilder, PPG
@@ -37,7 +39,6 @@ class Tcl(ModuleBuilder):
 
 
 class Tk(ModuleBuilder):
-
     m_build_cwd = "unix"
 
     @property
@@ -107,7 +108,7 @@ class TkInter(ModuleBuilder):
     """
 
     m_debian = "-tk-dev"
-    m_telltale = ["{include}/tk", "{include}/tk.h"]
+    m_telltale: ClassVar[list] = ["{include}/tk", "{include}/tk.h"]
 
     @classmethod
     def candidate_modules(cls):

--- a/src/portable_python/external/xcpython.py
+++ b/src/portable_python/external/xcpython.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 import runez
 
 from portable_python import LinkerOutcome, ModuleBuilder, PPG
@@ -64,7 +66,7 @@ class Gdbm(ModuleBuilder):
     """
 
     m_debian = "libgdbm-dev"
-    m_telltale = ["{include}/gdbm.h"]
+    m_telltale: ClassVar[list] = ["{include}/gdbm.h"]
 
     @property
     def url(self):
@@ -102,7 +104,7 @@ class LibFFI(ModuleBuilder):
     """
 
     m_debian = "!libffi-dev"
-    m_telltale = ["{include}/ffi.h", "{include}/ffi/ffi.h"]
+    m_telltale: ClassVar[list] = ["{include}/ffi.h", "{include}/ffi/ffi.h"]
 
     xenv_CFLAGS = "-fPIC"
 
@@ -163,7 +165,6 @@ class Openssl(ModuleBuilder):
 
 
 class Ncurses(ModuleBuilder):
-
     m_include = "ncursesw"
 
     xenv_CFLAGS = "-fPIC"
@@ -231,8 +232,14 @@ class Readline(ModuleBuilder):
 
     def _do_linux_compile(self):
         self.run_configure(
-            "./configure", "--disable-shared", "--enable-static", "--with-curses", "--enable-multibyte",
-            "--disable-install-examples", "--disable-docs", "--enable-portable-binary",
+            "./configure",
+            "--disable-shared",
+            "--enable-static",
+            "--with-curses",
+            "--enable-multibyte",
+            "--disable-install-examples",
+            "--disable-docs",
+            "--enable-portable-binary",
         )
         self.run_make(cpu_count=0)
         self.run_make("install", cpu_count=0)
@@ -245,7 +252,7 @@ class Sqlite(ModuleBuilder):
     """
 
     m_debian = "+libsqlite3-dev"
-    m_telltale = ["{include}/sqlite3.h"]
+    m_telltale: ClassVar[list] = ["{include}/sqlite3.h"]
 
     xenv_CFLAGS = "-fPIC"
 
@@ -265,7 +272,12 @@ class Sqlite(ModuleBuilder):
 
     def _do_linux_compile(self):
         self.run_configure(
-            "./configure", "--enable-shared=no", "--enable-static=yes", "--disable-tcl", "--disable-readline", "--with-pic=yes"
+            "./configure",
+            "--enable-shared=no",
+            "--enable-static=yes",
+            "--disable-tcl",
+            "--disable-readline",
+            "--with-pic=yes",
         )
         self.run_make()
         self.run_make("install")
@@ -279,7 +291,7 @@ class Uuid(ModuleBuilder):
 
     m_debian = "+uuid-dev"
     m_include = "uuid"
-    m_telltale = ["{include}/uuid/uuid.h"]
+    m_telltale: ClassVar[list] = ["{include}/uuid/uuid.h"]
 
     xenv_CFLAGS = "-fPIC"
 
@@ -298,7 +310,6 @@ class Uuid(ModuleBuilder):
 
 
 class Xz(ModuleBuilder):
-
     m_telltale = "{include}/lzma.h"
 
     def auto_select_reason(self):
@@ -316,8 +327,14 @@ class Xz(ModuleBuilder):
     def _do_linux_compile(self):
         self.run_configure(
             "./configure",
-            "--enable-shared=no", "--enable-static=yes", "--with-pic=yes", "--disable-rpath",
-            "--disable-dependency-tracking", "--disable-doc", "--disable-nls", "--without-libintl-prefix",
+            "--enable-shared=no",
+            "--enable-static=yes",
+            "--with-pic=yes",
+            "--disable-rpath",
+            "--disable-dependency-tracking",
+            "--disable-doc",
+            "--disable-nls",
+            "--without-libintl-prefix",
         )
         self.run_make()
         self.run_make("install")

--- a/src/portable_python/inspector.py
+++ b/src/portable_python/inspector.py
@@ -11,7 +11,6 @@ from runez.render import PrettyTable
 from portable_python.tracking import Trackable, Tracker
 from portable_python.versions import PPG
 
-
 LOG = logging.getLogger(__name__)
 RX_DYNLIB = re.compile(r"^.*\.(so(\.[0-9.]+)?|dylib)$")
 
@@ -146,7 +145,6 @@ class LibAutoCorrect:
 
 
 class ModuleInfo:
-
     _regex = re.compile(r"^(.*?)\s*(\S+/(lib(64)?/.*))$")
 
     def __init__(self, inspector: "PythonInspector", name: str, payload: dict):
@@ -166,8 +164,7 @@ class ModuleInfo:
         path = self.filepath
         if path:
             if is_dyn_lib(path):
-                info = SoInfo(self.inspector, path)
-                return info
+                return SoInfo(self.inspector, path)
 
             if path.name.startswith("__init__."):
                 path = path.parent
@@ -200,7 +197,6 @@ class ModuleInfo:
 
 
 class CLibInfo(Trackable):
-
     def __init__(self, inspector: "PythonInspector", path: str, version: str, basename: str):
         self.inspector = inspector
         if not basename:
@@ -249,7 +245,6 @@ class CLibInfo(Trackable):
 
 
 class SoInfo(Trackable):
-
     def __init__(self, inspector: "PythonInspector", path):
         self.inspector = inspector
         self.path = runez.to_path(path)
@@ -286,7 +281,7 @@ class SoInfo(Trackable):
             if runez.which(program):
                 r = runez.run(*cmd, path, fatal=False, logger=None)
                 if not r.succeeded:
-                    logging.warning("%s exited with code %s for %s: %s" % (program, r.exit_code, path, r.full_output))
+                    logging.warning("%s exited with code %s for %s: %s", program, r.exit_code, path, r.full_output)
                     return program, None
 
                 return program, r.output
@@ -397,7 +392,6 @@ def get_lib_type(install_folder, path, basename):
 
 
 class PythonInspector:
-
     default = "_bz2,_ctypes,_curses,_decimal,_dbm,_gdbm,_lzma,_tkinter,_sqlite3,_ssl,_uuid,pip,readline,pyexpat,setuptools,zlib"
     additional = "_asyncio,_functools,_tracemalloc,dbm.gnu,ensurepip,ossaudiodev,spwd,sys,tkinter,venv,wheel"
 
@@ -500,11 +494,15 @@ class PythonInspector:
     @staticmethod
     def parsed_version(output):
         """
-        Args:
-            output (str | None): Output to parse
+        Parameters
+        ----------
+        output : str | None
+            Output to parse
 
-        Returns:
-            (str | None): Simplified version number reported
+        Returns
+        -------
+        str | None
+            Simplified version number reported
         """
         if output:
             for line in output.splitlines():
@@ -535,7 +533,6 @@ def _find_parent_subfolder(folder, basename):
 
 
 class FullSoReport:
-
     def __init__(self, inspector: PythonInspector):
         self.inspector = inspector
         self.size = 0

--- a/src/portable_python/inspector.py
+++ b/src/portable_python/inspector.py
@@ -56,10 +56,14 @@ class LibAutoCorrect:
 
     def __init__(self, prefix, install_folder, ppp_marker=None):
         """
-        Args:
-            prefix (str): Prefix used in ./configure
-            install_folder (pathlib.Path): Installation folder to scan (all paths will be relative to this)
-            ppp_marker (str | None): Associated ppp-marker, if any
+        Parameters
+        ----------
+        prefix: str
+            Prefix used in ./configure
+        install_folder : pathlib.Path
+            Installation folder to scan (all paths will be relative to this)
+        ppp_marker : str | None
+            Path to ppp-marker, if any
         """
         self.prefix = prefix
         self.install_folder = install_folder
@@ -102,6 +106,7 @@ class LibAutoCorrect:
     def _auto_correct_macos(self, path):
         """
         On macos, we use install_name_tool, example:
+
             install_name_tool -add_rpath @executable_path/../lib .../bin/python
             install_name_tool -change /<prefix>/lib/libpython3.9.dylib @rpath/libpython3.9.dylib .../bin/python
 
@@ -494,6 +499,8 @@ class PythonInspector:
     @staticmethod
     def parsed_version(output):
         """
+        Version mentioned in `output`
+
         Parameters
         ----------
         output : str | None

--- a/src/portable_python/tracking.py
+++ b/src/portable_python/tracking.py
@@ -2,7 +2,6 @@ import runez
 
 
 class Trackable:
-
     tracked_category = None
 
     def __eq__(self, other):
@@ -16,7 +15,6 @@ class Trackable:
 
 
 class TrackedCollection:
-
     def __init__(self, name):
         self.name = name
         self.items = []
@@ -38,7 +36,6 @@ class TrackedCollection:
 
 
 class Tracker(TrackedCollection):
-
     def __init__(self, enum, name=None):
         self.kind = enum.__name__.replace("Type", "").lower()
         super().__init__(name or self.kind)

--- a/src/portable_python/versions.py
+++ b/src/portable_python/versions.py
@@ -6,6 +6,7 @@ Not trying to do historical stuff here, older (or EOL-ed) versions will be remov
 import logging
 import os
 import re
+from typing import ClassVar
 
 import runez
 from runez.http import RestClient
@@ -54,8 +55,10 @@ class VersionFamily:
 
     def get_builder(self):
         """
-        Returns:
-            (portable_python.PythonBuilder)
+        Returns
+        -------
+        portable_python.PythonBuilder
+            Builder implementation for this family
         """
 
 
@@ -105,7 +108,6 @@ class CPythonFamily(VersionFamily):
 
 
 class Folders:
-
     def __init__(self, config: Config, base=None, family=None, version=None):
         self.config = config
         self.base_folder = runez.resolved_path(base)
@@ -160,10 +162,21 @@ class Folders:
 
 
 class PPG:
-    """Globals"""
+    """
+    Global settings for portable-python
+
+    Attributes
+    ----------
+    families : dict[str, VersionFamily]
+        Mapping of family names to implementations
+    config : portable_python.config.Config
+        Global configuration
+    target : runez.system.PlatformId
+        Target platform
+    """
 
     cpython = CPythonFamily()
-    families = dict(cpython=cpython)
+    families: ClassVar[dict] = {"cpython": cpython}
     config = Config()
     target = config.target
 

--- a/src/portable_python/versions.py
+++ b/src/portable_python/versions.py
@@ -1,6 +1,7 @@
 """
-Tracking only a handful of most recent (and non-EOL) versions by design
-Not trying to do historical stuff here, older (or EOL-ed) versions will be removed from the list without notice
+Tracking only a handful of most recent (and non-EOL) versions by design.
+
+Not trying to do historical stuff here, older (or EOL-ed) versions will be removed from the list without notice.
 """
 
 import logging
@@ -50,11 +51,19 @@ class VersionFamily:
         self._fetch_versions()
         return self._versions
 
-    def get_available_versions(self) -> list:
-        """Implementation supplied by descendant: iterable of available versions, can be strings"""
+    def get_available_versions(self):
+        """
+        Available versions.
+
+        Returns
+        -------
+        list[Version]
+        """
 
     def get_builder(self):
         """
+        Builder implementation for this family.
+
         Returns
         -------
         portable_python.PythonBuilder

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,14 @@
 import runez
-from runez.conftest import cli, logged, temp_folder  # noqa: fixtures
+from runez.conftest import cli, logged, temp_folder
 from runez.http import GlobalHttpCalls
 
 from portable_python.cli import main
 
-
 GlobalHttpCalls.forbid()
+
+# These are fixtures, satisfying linters with an assert
+assert logged
+assert temp_folder
 
 # Ensure common logging setup is done throughout all tests (even tests not invoking cli)
 runez.log.setup(debug=True, console_format="%(levelname)s %(message)s", locations=None)

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -48,7 +48,7 @@ def test_cleanup(cli, monkeypatch):
     assert "MACOSX_DEPLOYMENT_TARGET" not in cli.logged
     assert "selected: all" in cli.logged
     assert f"Would symlink {install_dir}/bin/pip{f.mm} <- {install_dir}/bin/pip" in cli.logged
-    assert f"Would symlink {lib}/python{f.mm}/config-{f.mm}-darwin/libpython{f.mm}.a <- {lib}/libpython{f.mm}.a"
+    assert f"Would symlink {lib}/python{f.mm}/config-{f.mm}-darwin/libpython{f.mm}.a <- {lib}/libpython{f.mm}.a" in cli.logged
     assert f"Would tar {install_dir} -> dist/cpython-{f.version}-linux-x86_64.tar.gz" in cli.logged
 
     runez.touch("bin/brew", logger=None)

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -133,7 +133,7 @@ class MockSharedExeRun:
         if args[1] == "--print-rpath":
             return self.prefix
 
-    def _macos_run(self, program, *args):
+    def _macos_run(self, program, *_):
         if program == "otool":
             return f"foo/bin/python:\n {self.prefix}/lib/libpython3.9.dylib (...)\n /usr/lib/... (...)"
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -3,7 +3,6 @@ from runez.http import RestClient
 from portable_python import BuildSetup
 from portable_python.versions import CPythonFamily, PPG
 
-
 REST_CLIENT = RestClient()
 GH_CPYTHON_SAMPLE = """
 [
@@ -21,10 +20,12 @@ PYTHON_ORG_SAMPLE = """
 """
 
 
-@REST_CLIENT.mock({
-    "https://www.python.org/ftp/python/": PYTHON_ORG_SAMPLE,
-    "https://api.github.com/repos/python/cpython/git/matching-refs/tags/v3.": GH_CPYTHON_SAMPLE,
-})
+@REST_CLIENT.mock(
+    {
+        "https://www.python.org/ftp/python/": PYTHON_ORG_SAMPLE,
+        "https://api.github.com/repos/python/cpython/git/matching-refs/tags/v3.": GH_CPYTHON_SAMPLE,
+    },
+)
 def test_list(cli, monkeypatch):
     # Edge cases
     monkeypatch.setattr(PPG, "config", None)

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = py{310,311,312}, coverage, docs, style
 skip_missing_interpreters = true
 
 [testenv]
-passenv = GITHUB_*
 setenv = COVERAGE_FILE={toxworkdir}/.coverage.{envname}
 usedevelop = True
 deps = -rrequirements.txt
@@ -28,9 +27,16 @@ commands = check-manifest
 
 [testenv:style]
 skip_install = True
-deps = flake8
-       flake8-import-order
-commands = flake8 {posargs:src/ tests/ setup.py}
+deps = ruff
+commands = ruff check --diff {posargs:}
+           ruff check --show-source {posargs:}
+           ruff format --diff {posargs:}
+
+[testenv:format]
+skip_install = True
+deps = ruff
+commands = ruff check --fix {posargs:}
+           ruff format {posargs:}
 
 [testenv:security]
 skip_install = True
@@ -53,11 +59,3 @@ directory = .tox/test-reports/htmlcov
 
 [pytest]
 cache_dir = .tox/.cache
-
-[flake8]
-max-line-length = 140
-max-complexity = 20
-show-source = True
-# See https://github.com/PyCQA/flake8-import-order
-import-order-style = edited
-application-import-names = portable_python

--- a/tox.ini
+++ b/tox.ini
@@ -18,13 +18,6 @@ commands = coverage combine
            coverage xml
            coverage html
 
-[testenv:docs]
-skip_install = True
-deps = check-manifest
-       readme-renderer
-commands = check-manifest
-           python setup.py check --strict --restructuredtext
-
 [testenv:style]
 skip_install = True
 deps = ruff
@@ -32,16 +25,18 @@ commands = ruff check --diff {posargs:}
            ruff check --show-source {posargs:}
            ruff format --diff {posargs:}
 
-[testenv:format]
+[testenv:reformat]
 skip_install = True
 deps = ruff
 commands = ruff check --fix {posargs:}
            ruff format {posargs:}
 
-[testenv:security]
+[testenv:docs]
 skip_install = True
-deps = bandit
-commands = bandit {posargs:-r src/}
+deps = check-manifest
+       readme-renderer
+commands = check-manifest
+           python setup.py check --strict --restructuredtext
 
 [check-manifest]
 ignore = .dockerignore


### PR DESCRIPTION
Using `ruff` instead of `flake8`.
Turned on most lint checks and addressed them all.
Moving to `numpy` docstring convention (from `google` style)