### PR TITLE
Bump zlib version from 1.3 to 1.3.1

### DIFF
--- a/src/portable_python/external/xcpython.py
+++ b/src/portable_python/external/xcpython.py
@@ -344,7 +344,7 @@ class Zlib(ModuleBuilder):
 
     @property
     def version(self):
-        return self.cfg_version("1.3")
+        return self.cfg_version("1.3.1")
 
     def _do_linux_compile(self):
         self.run_configure("./configure", "--static")


### PR DESCRIPTION
Two days ago zlib 1.3.1 got released, and the link to 1.3 gives 404 now and the build fails:

```
--------------
-- zlib:1.3 --
--------------
ERROR GET https://zlib.net/zlib-1.3.tar.gz [404]
INFO Overall compilation failed (ran for 8 seconds 758 ms)
```