### PR TITLE
Update the path for zlib tarballs

### DIFF
--- a/src/portable_python/external/xcpython.py
+++ b/src/portable_python/external/xcpython.py
@@ -340,7 +340,7 @@ class Zlib(ModuleBuilder):
 
     @property
     def url(self):
-        return f"https://zlib.net/zlib-{self.version}.tar.gz"
+        return f"https://zlib.net/fossils/zlib-{self.version}.tar.gz"
 
     @property
     def version(self):


### PR DESCRIPTION
The current link for zlib-1.3 returns 404 because the zlib team have published a new release 1.3.1 and removed the old one. While this repo has been updated with zlib-1.3.1, the PyPI package will be broken until a new release of `portable-python` is published there.
The `/fossils/` path contains all zlib releases, including the latest one, so use that instead.