### PR TITLE
Introduce PATH, LD_LIBRARY_PATH and PKG_CONFIG_PATH from running environment

### DIFF
--- a/src/portable_python/__init__.py
+++ b/src/portable_python/__init__.py
@@ -526,10 +526,15 @@ class ModuleBuilder:
 
     def xenv_PATH(self):
         yield f"{self.deps}/bin"
+        yield from os.environ.get("PATH", "").split(":")
         yield "/usr/bin"
         yield "/bin"
 
+    def xenv_LD_LIBRARY_PATH(self):
+        yield from os.environ.get("LD_LIBRARY_PATH", "").split(":")
+
     def xenv_PKG_CONFIG_PATH(self):
+        yield from os.environ.get("PKG_CONFIG_PATH", "").split(":")
         if self.modules.selected:
             yield f"{self.deps_lib}/pkgconfig"
 


### PR DESCRIPTION
This pull request introduce the environment variables (PATH, LD_LIBRARY_PATH and PKG_CONFIG_PATH) from `portable-python` executing environment.

This will allow to use gcc/g++, and also custom library path when compiling the portable python.