### PR TITLE
Update additional packages installation

### DIFF
--- a/src/portable_python/cpython.py
+++ b/src/portable_python/cpython.py
@@ -228,7 +228,7 @@ class Cpython(PythonBuilder):
 
                 self.run_python(cmd)
 
-            self.run_python("-mpip", "install", *runez.flattened(additional))
+            self.run_python("-mpip", "install", "--no-cache-dir", "--upgrade", *runez.flattened(additional))
 
         runez.abort_if(not runez.DRYRUN and not self.bin_python, f"Can't find bin/python in {self.bin_folder}")
         PPG.config.ensure_main_file_symlinks(self)


### PR DESCRIPTION
This commit allows upgrade the packages coming with Python as default, e.g. pip and setuptools, if they are specified in the section of `cpython-additional-packages` in `portable-python.yaml`.