### PR TITLE
Add support to patch sources after download

### DIFF
--- a/portable-python.yml
+++ b/portable-python.yml
@@ -19,3 +19,10 @@ folders:
 cpython-additional-packages:
 #  - Pillow==10.0.0
 #  - flake8==6.0.0
+
+# Uncomment if you need to patch the source code of a module before compiling it
+#cpython-modules: zlib
+#zlib-patches:
+#  - file: configure
+#    regex: "# start off configure.log"
+#    replacement: "echo starting zlib configure script with patches"

--- a/src/portable_python/__init__.py
+++ b/src/portable_python/__init__.py
@@ -491,6 +491,9 @@ class ModuleBuilder:
     def cfg_version(self, default):
         return PPG.config.get_value("%s-version" % self.m_name) or default
 
+    def cfg_patches(self):
+        return PPG.config.get_value("%s-patches" % self.m_name)
+
     @property
     def url(self):
         """Url of source tarball, if any"""
@@ -639,6 +642,7 @@ class ModuleBuilder:
                         folder = folder / self.m_build_cwd
 
                     with runez.CurrentFolder(folder):
+                        self._apply_patches()
                         self._prepare()
                         func()
                         self._finalize()
@@ -651,6 +655,15 @@ class ModuleBuilder:
 
                     else:
                         os.environ[k] = v
+
+    def _apply_patches(self):
+        if patches := self.cfg_patches():
+            for patch in patches:
+                if runez.DRYRUN:
+                    print(f"Would apply patch: {patch}")
+                else:
+                    print(f"Applying patch: {patch}")
+                    patch_file(patch["file"], patch["regex"], patch["replacement"])
 
     def _get_env_vars(self):
         """Yield all found env vars, first found wins"""


### PR DESCRIPTION
This feature enables us to address this issue in python's upstream configure scripts:

https://github.com/codrsquad/portable-python/issues/58

I know the readme says it's a guideline to not patch. I suppose that makes sense for the project not to patch anything out of the box.  However, adding this feature seems reasonable and sensible.
