### PR TITLE
Retired EOL versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -1,16 +1,11 @@
-# How to create a dev venv
+# Local development
 
-If you have tox, you can run: `tox -re venv`, that will get you a `.venv/`
-ready to go.
-
-If you don't have tox, you can run this (any python 3.6+ will do):
+Create a dev venv:
 
 ```shell
-rm -rf .venv
-/usr/bin/python3 -mvenv .venv
-.venv/bin/pip install -U pip
-.venv/bin/pip install -r requirements.txt -r tests/requirements.txt
-.venv/bin/pip install -e .
+uv venv
+uv pip install -r requirements.txt -r tests/requirements.txt
+uv pip install -e .
 ```
 
 You can then run `portable-python` from that venv:
@@ -24,10 +19,8 @@ You can then run `portable-python` from that venv:
 # Run the tests
 
 If you have tox, just run: `tox` to run all the tests. You can also run:
-- `tox -e py39` to run with just one python version
+- `tox -e py313` to run with just one python version
 - `tox -e style` to check PEP8 formatting
-- `tox -r` if you changed any `requirements.txt` (`-r` is short for `--recreate`)
-- `tox -re py39` to recreate and run `py39` only
 - etc
 
 If you don't have tox, you can run the tests with: `.venv/bin/pytest tests/`
@@ -49,7 +42,7 @@ You can easily run `portable-python` in a debugger.
 In PyCharm for example, you would simply browse to `.venv/bin/portable-python`
 then right-click and select "Debug portable-python".
 You can then edit the build/run configuration in PyCharm, add some "Parameters" to it,
-like for example `build-report 3.10.5`, and then set breakpoints wherever you like.
+like for example `build-report 3.13.2`, and then set breakpoints wherever you like.
 
 There is a `--dryrun` mode that can come in very handy for rapid iterations.
 
@@ -71,5 +64,5 @@ docker run -it -v./:/src/ portable-python-jammy /bin/bash
 Now inside docker, you run a build:
 
 ```shell
-portable-python build 3.11.4
+portable-python build 3.13.2
 ```

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author="Zoran Simic zoran@simicweb.com",
     keywords="python, portable, binary",
     url="https://github.com/codrsquad/portable-python",
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     entry_points={
         "console_scripts": [
             "portable-python = portable_python.__main__:main",
@@ -22,7 +22,6 @@ setup(
         "Operating System :: Unix",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/src/portable_python/versions.py
+++ b/src/portable_python/versions.py
@@ -74,7 +74,7 @@ class VersionFamily:
 class CPythonFamily(VersionFamily):
     """Implementation for cpython"""
 
-    min_version = "3.7"  # Earliest non-EOL known to compile well
+    min_version = "3.9"  # Earliest non-EOL known to compile well
 
     @runez.cached_property
     def client(self):

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -7,7 +7,7 @@ REST_CLIENT = RestClient()
 GH_CPYTHON_SAMPLE = """
 [
 {"ref": "refs/tags/v3.9.7"},
-{"ref": "refs/tags/v3.8.12"},
+{"ref": "refs/tags/v3.13.3"},
 {"ref": "refs/tags/v3.5.10"}
 ]
 """
@@ -15,7 +15,7 @@ GH_CPYTHON_SAMPLE = """
 PYTHON_ORG_SAMPLE = """
 <a href="3.9.5/">3.9.5/</a>
 <a href="3.9.6/">3.9.6/</a>
-<a href="3.8.11/">3.9.11/</a>
+<a href="3.13.2/">3.13.2/</a>
 <a href="3.5.10/">3.5.10/</a>
 """
 
@@ -34,12 +34,12 @@ def test_list(cli, monkeypatch):
     assert setup.python_spec.version == PPG.cpython.latest
 
     cp = CPythonFamily()
-    assert str(cp.latest) == "3.9.6"
+    assert str(cp.latest) == "3.13.2"
 
     monkeypatch.setattr(PPG.cpython, "_versions", None)
     cli.run("list")
     assert cli.succeeded
-    assert cli.logged.stdout.contents().strip() == "cpython:\n  3.9: 3.9.6\n  3.8: 3.8.11"
+    assert cli.logged.stdout.contents().strip() == "cpython:\n  3.13: 3.13.2\n  3.9: 3.9.6"
 
     cli.run("list", "--json")
     assert cli.succeeded
@@ -52,4 +52,4 @@ def test_list(cli, monkeypatch):
     monkeypatch.setattr(PPG.cpython, "_versions", None)
     cli.run("-c", cli.tests_path("sample-config1.yml"), "list")
     assert cli.succeeded
-    assert cli.logged.stdout.contents().strip() == "cpython:\n  3.9: 3.9.7\n  3.8: 3.8.12"
+    assert cli.logged.stdout.contents().strip() == "cpython:\n  3.13: 3.13.3\n  3.9: 3.9.7"


### PR DESCRIPTION
List and exercise tests only on py3.9+ (older versions can still be compiled, as the version to build is given explicitly on command line)