### PR TITLE
Enable subprocess test coverage gathering

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,6 +49,10 @@ ignore = .dockerignore
          tests/**
          tox.ini
 
+[coverage:run]
+concurrency =
+    thread
+patch = subprocess
 [coverage:xml]
 output = .tox/test-reports/coverage.xml
 [coverage:html]


### PR DESCRIPTION
This catches ~10 more lines covered